### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 A forked version of [the official Knowledge Graph Memory Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory).
 
+<a href="https://glama.ai/mcp/servers/4mqwh1toao">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/4mqwh1toao/badge" alt="DuckDB Knowledge Graph Memory Server MCP server" />
+</a>
+
 ## Installation
 
 ### Installing via Smithery


### PR DESCRIPTION
This PR adds a badge for the [MCP DuckDB Knowledge Graph Memory Server](https://glama.ai/mcp/servers/4mqwh1toao) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/4mqwh1toao">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/4mqwh1toao/badge" alt="DuckDB Knowledge Graph Memory Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.